### PR TITLE
fix(api): add version suffix to API endpoints

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-pond-04b2eb800.yml
+++ b/.github/workflows/azure-static-web-apps-kind-pond-04b2eb800.yml
@@ -16,12 +16,6 @@ jobs:
     name: Build and Deploy Job
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: |
-          yarn install
-          yarn workspace @ddradar/core build
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
@@ -37,7 +31,7 @@ jobs:
           routes_location: '/'
           ###### End of Repository/Build Configurations ######
         env:
-          API_URL: '/api'
+          API_URL: '/api/v1'
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-lemon-water-096a66800.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-water-096a66800.yml
@@ -37,7 +37,7 @@ jobs:
           routes_location: '/'
           ###### End of Repository/Build Configurations ######
         env:
-          API_URL: '/api'
+          API_URL: '/api/v1'
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "API: Launch",
       "type": "func",
-      "command": "host start",
+      "command": "start --cors http://localhost:3000/",
       "problemMatcher": "$func-watch",
       "isBackground": true,
       "dependsOn": "API: Build",

--- a/README-ja.md
+++ b/README-ja.md
@@ -29,7 +29,7 @@ yarn
   - `NODE_TLS_REJECT_UNAUTHORIZED`: `0`
 
 - クライアントとAPIの統合開発を行う場合は、下記の環境変数を設定してください。
-  - `API_URL`: `http://localhost:7071/api`
+  - `API_URL`: `http://localhost:7071/api/v1`
 
 ## Develop Command
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn
   - `NODE_TLS_REJECT_UNAUTHORIZED`: `0`
 
 - If you want to develop client with API integration, set env below.
-  - `API_URL`: `http://localhost:7071/api`
+  - `API_URL`: `http://localhost:7071/api/v1`
 
 ## Develop Command
 

--- a/api/getCourseInfo/README-ja.md
+++ b/api/getCourseInfo/README-ja.md
@@ -17,7 +17,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET api/courses/*:id*
+> GET api/v1/courses/*:id*
 
 ## Parameters
 

--- a/api/getCourseInfo/README.md
+++ b/api/getCourseInfo/README.md
@@ -17,7 +17,7 @@ Get course and orders information that match the specified ID.
 
 No need Authentication.
 
-> GET api/courses/*:id*
+> GET api/v1/courses/*:id*
 
 ## Parameters
 

--- a/api/getCourseInfo/function.json
+++ b/api/getCourseInfo/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "courses/{id:regex(^[01689bdiloqDIOPQ]{{32}}$)}"
+      "route": "v1/courses/{id:regex(^[01689bdiloqDIOPQ]{{32}}$)}"
     },
     {
       "type": "http",

--- a/api/getCourseInfo/index.test.ts
+++ b/api/getCourseInfo/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import { CourseSchema } from '../db'
 import getCourseInfo from '.'
 
-describe('GET /api/courses', () => {
+describe('GET /api/v1/courses', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/getCourseList/README-ja.md
+++ b/api/getCourseList/README-ja.md
@@ -16,7 +16,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET api/courses
+> GET api/v1/courses
 
 ## Response
 

--- a/api/getCourseList/README.md
+++ b/api/getCourseList/README.md
@@ -16,7 +16,7 @@ Get course information list.
 
 No need Authentication.
 
-> GET api/courses
+> GET api/v1/courses
 
 ## Response
 

--- a/api/getCourseList/function.json
+++ b/api/getCourseList/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "courses"
+      "route": "v1/courses"
     },
     {
       "type": "http",

--- a/api/getCourseList/index.test.ts
+++ b/api/getCourseList/index.test.ts
@@ -9,7 +9,7 @@ type ShrinkedCourse = Omit<CourseSchema, 'orders'> & {
   orders: Omit<Order, 'chartOrder'>[]
 }
 
-describe('GET /api/courses', () => {
+describe('GET /api/v1/courses', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/getSongInfo/README-ja.md
+++ b/api/getSongInfo/README-ja.md
@@ -17,7 +17,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET api/songs/*:id*
+> GET api/v1/songs/*:id*
 
 ## Parameters
 

--- a/api/getSongInfo/README.md
+++ b/api/getSongInfo/README.md
@@ -17,7 +17,7 @@ Get song and charts information that match the specified ID.
 
 No need Authentication.
 
-> GET api/songs/*:id*
+> GET api/v1/songs/*:id*
 
 ## Parameters
 

--- a/api/getSongInfo/function.json
+++ b/api/getSongInfo/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "songs/{id:regex(^[01689bdiloqDIOPQ]{{32}}$)}"
+      "route": "v1/songs/{id:regex(^[01689bdiloqDIOPQ]{{32}}$)}"
     },
     {
       "type": "http",

--- a/api/getSongInfo/index.test.ts
+++ b/api/getSongInfo/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { SongSchema } from '../db'
 import getSongInfo from '.'
 
-describe('GET /api/songs', () => {
+describe('GET /api/v1/songs', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/postSongInfo/README-ja.md
+++ b/api/postSongInfo/README-ja.md
@@ -16,7 +16,7 @@
 
 `administrator` ロールを持つユーザーで[認証](../../docs/api/authentication-ja.md#login)する必要があります。
 
-> POST /api/admin/songs
+> POST /api/v1/admin/songs
 
 ## Parameters
 

--- a/api/postSongInfo/README.md
+++ b/api/postSongInfo/README.md
@@ -17,7 +17,7 @@ Add or update song and charts information.
 
 Need [Authentication](../../docs/api/authentication.md#login) with `administrator` role.
 
-> POST /api/admin/songs
+> POST /api/v1/admin/songs
 
 ## Parameters
 

--- a/api/postSongInfo/function.json
+++ b/api/postSongInfo/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["post"],
-      "route": "admin/songs"
+      "route": "v1/admin/songs"
     },
     {
       "type": "http",

--- a/api/postSongInfo/index.test.ts
+++ b/api/postSongInfo/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { SongSchema } from '../db'
 import postSongInfo from '.'
 
-describe('POST /api/admin/songs', () => {
+describe('POST /api/v1/admin/songs', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/postSongInfo/index.ts
+++ b/api/postSongInfo/index.ts
@@ -16,7 +16,7 @@ const httpTrigger: AzureFunction = async (
     return
   }
 
-  const container = getContainer('Songs', true)
+  const container = getContainer('Songs')
   const { resource } = await container.items.upsert<SongSchema>(req.body)
   if (!resource) throw new Error(`Failed upsert id:${req.body.id}`)
   const responseBody: SongSchema = {

--- a/api/searchCharts/README-ja.md
+++ b/api/searchCharts/README-ja.md
@@ -17,7 +17,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET /api/charts/*:playStyle*/*:level*
+> GET /api/v1/charts/*:playStyle*/*:level*
 
 ## Parameters
 

--- a/api/searchCharts/README.md
+++ b/api/searchCharts/README.md
@@ -17,7 +17,7 @@ Get charts that match the specified conditions.
 
 No need Authentication.
 
-> GET /api/charts/*:playStyle*/*:level*
+> GET /api/v1/charts/*:playStyle*/*:level*
 
 ## Parameters
 

--- a/api/searchCharts/function.json
+++ b/api/searchCharts/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "charts/{playStyle:int:range(1,2)}/{level:int:range(1,20)}"
+      "route": "v1/charts/{playStyle:int:range(1,2)}/{level:int:range(1,20)}"
     },
     {
       "type": "http",

--- a/api/searchCharts/index.test.ts
+++ b/api/searchCharts/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { SongSchema } from '../db'
 import searchCharts from '.'
 
-describe('GET /api/charts', () => {
+describe('GET /api/v1/charts', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/searchSongByName/README-ja.md
+++ b/api/searchSongByName/README-ja.md
@@ -17,7 +17,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET /api/songs/name/0&series=0
+> GET /api/v1/songs/name/0&series=0
 
 ## Parameters
 

--- a/api/searchSongByName/README.md
+++ b/api/searchSongByName/README.md
@@ -17,7 +17,7 @@ Get a list of song information that matches the specified conditions.
 
 No need Authentication.
 
-> GET /api/songs/name/0&series=0
+> GET /api/v1/songs/name/0&series=0
 
 ## Parameters
 

--- a/api/searchSongByName/function.json
+++ b/api/searchSongByName/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "songs/name/{name:int:min(0):max(36)}"
+      "route": "v1/songs/name/{name:int:min(0):max(36)}"
     },
     {
       "type": "http",

--- a/api/searchSongByName/index.test.ts
+++ b/api/searchSongByName/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { SongSchema } from '../db'
 import searchSong from '.'
 
-describe('GET /api/songs/name', () => {
+describe('GET /api/v1/songs/name', () => {
   let context: Context
 
   beforeEach(() => {

--- a/api/searchSongBySeries/README-ja.md
+++ b/api/searchSongBySeries/README-ja.md
@@ -17,7 +17,7 @@ English version is [here](./README.md).
 
 認証は不要です。
 
-> GET /api/songs/series/0&name=0
+> GET /api/v1/songs/series/0&name=0
 
 ## Parameters
 

--- a/api/searchSongBySeries/README.md
+++ b/api/searchSongBySeries/README.md
@@ -17,7 +17,7 @@ Get a list of song information that matches the specified conditions.
 
 No need Authentication.
 
-> GET /api/songs/series/0&name=0
+> GET /api/v1/songs/series/0&name=0
 
 ## Parameters
 

--- a/api/searchSongBySeries/function.json
+++ b/api/searchSongBySeries/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "authLevel": "anonymous",
       "methods": ["get"],
-      "route": "songs/series/{series:int:min(0):max(16)}"
+      "route": "v1/songs/series/{series:int:min(0):max(16)}"
     },
     {
       "type": "http",

--- a/api/searchSongBySeries/index.test.ts
+++ b/api/searchSongBySeries/index.test.ts
@@ -5,7 +5,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { SongSchema } from '../db'
 import searchSong from '.'
 
-describe('GET /api/songs/series', () => {
+describe('GET /api/v1/songs/series', () => {
   let context: Context
 
   beforeEach(() => {

--- a/routes.json
+++ b/routes.json
@@ -17,7 +17,7 @@
       "allowedRoles": ["administrator"]
     },
     {
-      "route": "/api/admin/*",
+      "route": "/api/v1/admin/*",
       "allowedRoles": ["administrator"]
     },
     {


### PR DESCRIPTION
[Post Song Info API](https://github.com/ddradar/ddradar/tree/master/api/postSongInfo) does not work because `/api/admin` route is reserved by Azure.
This PR changes all API endpoints from `/api/*` to `/api/v1/*`.