### PR TITLE
fix(api): avoid use continuation token

### DIFF
--- a/api/getUserList/README-ja.md
+++ b/api/getUserList/README-ja.md
@@ -19,8 +19,6 @@ English version is [here](./README.md).
 
 > GET api/v1/users?area=0&name=foo&code=10000000
 
-> GET api/v1/users?token=foo
-
 ## Parameters
 
 |名前|型|説明|
@@ -28,7 +26,6 @@ English version is [here](./README.md).
 |`area`|integer|[エリアコード](../../docs/db/users-ja.md#area)。未指定時には全てのエリアから検索します。|
 |`name`|string|検索するユーザー名(部分一致)。未指定時には全てのユーザー名から検索します。|
 |`code`|integer|DDR CODE (完全一致)。`10000000`以上`99999999`以下の範囲。未指定時には全てのDDR CODEから検索します。|
-|`token`|string|2ページ目以降のデータを続けて取得するためのトークン文字列。通常、ユーザーが直接指定する必要はありません。|
 
 ## Response
 
@@ -41,32 +38,24 @@ English version is [here](./README.md).
   <summary>サンプル</summary>
 
 ```json
-{
-  "count": 2,
-  "next": null,
-  "result": [
-    {
-      "id": "afro0001",
-      "name": "AFRO",
-      "area": 13,
-      "code": 10000000
-    },
-    {
-      "id": "emi",
-      "name": "TOSHIBA EMI",
-      "area": 0
-    },
-  ]
-}
+[
+  {
+    "id": "afro0001",
+    "name": "AFRO",
+    "area": 13,
+    "code": 10000000
+  },
+  {
+    "id": "emi",
+    "name": "TOSHIBA EMI",
+    "area": 0
+  },
+]
 ```
 
 </details>
 
-|名前|型|説明|
-|---|:--:|---|
-|`count`|integer|検索結果の件数|
-|`next`|string \| null|件数が最大件数を超えるとき、次のデータを取得するための問い合わせURI|
-|`result`|User\[\]|[User](#user)の配列(最大50件)|
+[User](#user)の配列
 
 #### User
 

--- a/api/getUserList/README.md
+++ b/api/getUserList/README.md
@@ -19,8 +19,6 @@ No need Authentication. Authenticated users can get their own data even if they 
 
 > GET api/v1/users?area=0&name=foo&code=10000000
 
-> GET api/v1/users?token=foo
-
 ## Parameters
 
 |Name|Type|Description|
@@ -28,7 +26,6 @@ No need Authentication. Authenticated users can get their own data even if they 
 |`area`|integer|optional: [Area code](../../docs/db/users.md#area).|
 |`name`|string|optional: User Name(partial match).|
 |`code`|integer|optional: DDR CODE. Should be `10000000` - `99999999`.|
-|`token`|string|Continuation token|
 
 ## Response
 
@@ -41,32 +38,24 @@ No need Authentication. Authenticated users can get their own data even if they 
   <summary>Sample</summary>
 
 ```json
-{
-  "count": 2,
-  "next": null,
-  "result": [
-    {
-      "id": "afro0001",
-      "name": "AFRO",
-      "area": 13,
-      "code": 10000000
-    },
-    {
-      "id": "emi",
-      "name": "TOSHIBA EMI",
-      "area": 0
-    },
-  ]
-}
+[
+  {
+    "id": "afro0001",
+    "name": "AFRO",
+    "area": 13,
+    "code": 10000000
+  },
+  {
+    "id": "emi",
+    "name": "TOSHIBA EMI",
+    "area": 0
+  },
+]
 ```
 
 </details>
 
-|Name|Type|Description|
-|----|:--:|-----------|
-|`count`|integer|result count|
-|`next`|string \| null|Next API endpoint to continue|
-|`result`|User\[\]|Array of [User](#user) (max:50)|
+Array of [User](#user)
 
 #### User
 

--- a/api/getUserList/index.test.ts
+++ b/api/getUserList/index.test.ts
@@ -7,7 +7,7 @@ import { getConnectionString, getContainer } from '../cosmos'
 import type { UserSchema } from '../db'
 import { AreaCode } from '../db/users'
 import { User } from '../user'
-import getUserList, { UserListResponse } from '.'
+import getUserList from '.'
 
 jest.mock('../auth')
 
@@ -45,8 +45,7 @@ describe('GET /api/v1/users', () => {
 
         // Assert
         expect(result.status).toBe(200)
-        expect((result.body as UserListResponse).result).toHaveLength(9)
-        expect((result.body as UserListResponse).next).toBe(null)
+        expect(result.body).toHaveLength(9)
       })
 
       test('returns users with logged in user', async () => {
@@ -64,34 +63,7 @@ describe('GET /api/v1/users', () => {
 
         // Assert
         expect(result.status).toBe(200)
-        expect((result.body as UserListResponse).result).toHaveLength(10)
-        expect((result.body as UserListResponse).next).toBe(null)
-      })
-
-      test('returns users with continuationToken', async () => {
-        // Arrange - Act
-        const result = await getUserList(null, req)
-
-        // Assert
-        expect(result.status).toBe(200)
-        expect((result.body as UserListResponse).result).toHaveLength(50)
-        expect((result.body as UserListResponse).next).not.toBe(null)
-
-        // Arrange
-        const token =
-          (result.body as UserListResponse).next?.replace(
-            /^\/api\/v1\/users\?token=(.+)&.+$/,
-            '$1'
-          ) ?? ''
-        req.query = { token }
-
-        // Act
-        const nextResult = await getUserList(null, req)
-
-        // Assert
-        expect(nextResult.status).toBe(200)
-        expect((nextResult.body as UserListResponse).result).toHaveLength(49)
-        expect((nextResult.body as UserListResponse).next).toBe(null)
+        expect(result.body).toHaveLength(10)
       })
 
       test.each([
@@ -117,8 +89,7 @@ describe('GET /api/v1/users', () => {
 
         // Assert
         expect(result.status).toBe(200)
-        expect((result.body as UserListResponse).result).toStrictEqual(expected)
-        expect((result.body as UserListResponse).next).toBe(null)
+        expect(result.body).toStrictEqual(expected)
       })
 
       test.each<{ [key: string]: string }>([
@@ -135,7 +106,7 @@ describe('GET /api/v1/users', () => {
 
         // Assert
         expect(result.status).toBe(200)
-        expect((result.body as UserListResponse).result).toHaveLength(0)
+        expect(result.body).toHaveLength(0)
       })
 
       afterAll(async () => {

--- a/api/getUserList/index.ts
+++ b/api/getUserList/index.ts
@@ -4,26 +4,20 @@ import type { HttpRequest } from '@azure/functions'
 import { getClientPrincipal } from '../auth'
 import { getContainer } from '../cosmos'
 import { areaCodeList } from '../db/users'
-import type { NotFoundResult, SuccessResult } from '../function'
+import type { SuccessResult } from '../function'
 import type { User } from '../user'
-
-export type UserListResponse = {
-  next: string | null
-  result: User[]
-}
 
 /** Get user list that match the specified conditions. */
 export default async function (
   _context: unknown,
   req: Pick<HttpRequest, 'headers' | 'query'>
-): Promise<NotFoundResult | SuccessResult<UserListResponse>> {
+): Promise<SuccessResult<User[]>> {
   const clientPrincipal = getClientPrincipal(req)
   const loginId = clientPrincipal?.userId ?? ''
 
   const area = parseFloat(req.query.area)
   const name = req.query.name
   const code = parseFloat(req.query.code)
-  const token = req.query.token
 
   // Create SQL WHERE condition dynamically
   const conditions: string[] = ['(c.isPublic = true OR c.loginId = @loginId)']
@@ -42,31 +36,19 @@ export default async function (
   }
 
   const container = getContainer('Users', true)
-  const { resources, continuationToken, hasMoreResults } = await container.items
-    .query<User>(
-      {
-        query:
-          'SELECT c.id, c.name, c.area, c.code ' +
-          'FROM c ' +
-          `WHERE ${conditions.join(' AND ')}`,
-        parameters,
-      },
-      { maxItemCount: 50, continuationToken: token }
-    )
+  const { resources } = await container.items
+    .query<User>({
+      query:
+        'SELECT c.id, c.name, c.area, c.code ' +
+        'FROM c ' +
+        `WHERE ${conditions.join(' AND ')}`,
+      parameters,
+    })
     .fetchNext()
-
-  const queries = parameters
-    .map(p => p.name.replace('@', '&') + p.value?.toString())
-    .join('')
 
   return {
     status: 200,
     headers: { 'Content-type': 'application/json' },
-    body: {
-      next: hasMoreResults
-        ? `/api/v1/users?token=${continuationToken}${queries}`
-        : null,
-      result: resources,
-    },
+    body: resources,
   }
 }

--- a/client/pages/users/index.vue
+++ b/client/pages/users/index.vue
@@ -39,11 +39,8 @@
         striped
         :loading="loading"
         :mobile-cards="false"
-        :total="totalCount"
         paginated
-        backend-pagination
         per-page="50"
-        @page-change="onPageChange"
       >
         <template slot-scope="props">
           <b-table-column field="name" label="Name">
@@ -78,11 +75,6 @@ import { Component, Vue } from 'nuxt-property-decorator'
 
 import { AreaCode, areaList, User } from '~/types/api/user'
 
-type UserListResponse = {
-  next: string | null
-  result: User[]
-}
-
 @Component
 export default class UserListPage extends Vue {
   name: string = ''
@@ -99,16 +91,8 @@ export default class UserListPage extends Vue {
     value: v[1],
   }))
 
-  get totalCount() {
-    return this.nextUrl ? this.users.length + 1 : this.users.length
-  }
-
   getAreaName(areaCode: AreaCode) {
     return areaList[areaCode]
-  }
-
-  async onPageChange() {
-    await this.loadMoreData()
   }
 
   /** Load user info */
@@ -119,12 +103,10 @@ export default class UserListPage extends Vue {
       if (this.name) searchParams.append('name', this.name)
       if (this.area) searchParams.append('area', `${this.area}`)
       if (this.code) searchParams.append('code', `${this.code}`)
-      const { result, next } = await this.$http.$get<UserListResponse>(
-        '/api/v1/users',
-        { searchParams }
-      )
-      this.users = result
-      this.nextUrl = next
+      const users = await this.$http.$get<User[]>('/api/v1/users', {
+        searchParams,
+      })
+      this.users = users
     } catch (error) {
       this.$buefy.notification.open({
         message: error.message ?? error,
@@ -134,24 +116,6 @@ export default class UserListPage extends Vue {
       })
     }
     this.loading = false
-  }
-
-  async loadMoreData() {
-    if (!this.nextUrl) return
-    try {
-      const { result, next } = await this.$http.$get<UserListResponse>(
-        this.nextUrl
-      )
-      this.users.push(...result)
-      this.nextUrl = next
-    } catch (error) {
-      this.$buefy.notification.open({
-        message: error.message ?? error,
-        type: 'is-danger',
-        position: 'is-top',
-        hasIcon: true,
-      })
-    }
   }
 }
 </script>


### PR DESCRIPTION
Azure Functions cannot use continuation token
```log
Exception while executing function: Functions.getUserList Result: Failure
Exception: Error: Continuation tokens are not yet supported for cross partition queries
Stack: Error: Continuation tokens are not yet supported for cross partition queries
    at ParallelQueryExecutionContext.<anonymous> (/home/site/wwwroot/node_modules/@azure/cosmos/dist/index.js:3079:31)
    at Generator.next (<anonymous>)
    at fulfilled (/home/site/wwwroot/node_modules/tslib/tslib.js:111:62)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```