### PR TITLE
fix(ci): avoid use set-env (CVE-2020-15228)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,8 +56,8 @@ jobs:
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator -NoUI
           Get-CosmosDbEmulatorStatus
-          echo "::set-env name=COSMOS_DB_CONN::AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
-          echo "::set-env name=NODE_TLS_REJECT_UNAUTHORIZED::0"
+          echo "COSMOS_DB_CONN=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" >> $GITHUB_ENV
+          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
       - name: Test
         run: yarn test
       - name: Report Code Coverage to codecov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,8 +56,8 @@ jobs:
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator -NoUI
           Get-CosmosDbEmulatorStatus
-          echo "COSMOS_DB_CONN=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" >> $GITHUB_ENV
-          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
+          echo "COSMOS_DB_CONN=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Test
         run: yarn test
       - name: Report Code Coverage to codecov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,8 +56,8 @@ jobs:
           Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
           Start-CosmosDbEmulator -NoUI
           Get-CosmosDbEmulatorStatus
-          echo "COSMOS_DB_CONN=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "COSMOS_DB_CONN=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "NODE_TLS_REJECT_UNAUTHORIZED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Test
         run: yarn test
       - name: Report Code Coverage to codecov


### PR DESCRIPTION
see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/