### PR TITLE
test: migrate config files to TypeScript

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -3,7 +3,7 @@
   "extends": ["../.eslintrc.json"],
   "settings": {
     "node": {
-      "allowModules": ["@azure/functions"],
+      "allowModules": ["@azure/functions", "@jest/types"],
       "tryExtensions": [".ts", ".js", ".json", ".node"]
     }
   },

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config.InitialOptions = {
   collectCoverageFrom: [
     '<rootDir>/**/*.ts',
     '!**/*.d.ts',
+    '!<rootDir>/*.config.ts',
     '!**/__tests__/**',
     '!<rootDir>/core/**',
   ],

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -1,7 +1,7 @@
-/** @type {import('@jest/types/build/Config').InitialOptions} */
-module.exports = {
-  displayName: 'Functions',
-  automock: false,
+import { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'API',
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],
   testEnvironment: 'node',
@@ -9,14 +9,14 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
-  setupFiles: ['<rootDir>/__tests__/setupJest.js'],
+  globalSetup: '<rootDir>/__tests__/initDatabase.js',
   coverageDirectory: './coverage/',
   collectCoverage: true,
   collectCoverageFrom: [
     '<rootDir>/**/*.ts',
-    '!<rootDir>/db/index.ts',
     '!**/*.d.ts',
     '!**/__tests__/**',
     '!<rootDir>/core/**',
   ],
 }
+export default config

--- a/client/jest.config.ts
+++ b/client/jest.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('@jest/types/build/Config').InitialOptions} */
-module.exports = {
+import { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
   displayName: 'Client',
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',
@@ -29,3 +30,4 @@ module.exports = {
     '!**/__tests__/**',
   ],
 }
+export default config

--- a/functions/.eslintrc.json
+++ b/functions/.eslintrc.json
@@ -3,7 +3,7 @@
   "extends": ["../.eslintrc.json"],
   "settings": {
     "node": {
-      "allowModules": ["@azure/functions", "jest-fetch-mock"],
+      "allowModules": ["@azure/functions", "@jest/types", "jest-fetch-mock"],
       "tryExtensions": [".ts", ".js", ".json", ".node"]
     }
   },

--- a/functions/jest.config.ts
+++ b/functions/jest.config.ts
@@ -1,6 +1,8 @@
-/** @type {import('@jest/types/build/Config').InitialOptions} */
-module.exports = {
-  displayName: 'API',
+import { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  displayName: 'Functions',
+  automock: false,
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],
   testEnvironment: 'node',
@@ -8,13 +10,15 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
-  globalSetup: '<rootDir>/__tests__/initDatabase.js',
+  setupFiles: ['<rootDir>/__tests__/setupJest.js'],
   coverageDirectory: './coverage/',
   collectCoverage: true,
   collectCoverageFrom: [
     '<rootDir>/**/*.ts',
+    '!<rootDir>/db/index.ts',
     '!**/*.d.ts',
     '!**/__tests__/**',
     '!<rootDir>/core/**',
   ],
 }
+export default config

--- a/functions/jest.config.ts
+++ b/functions/jest.config.ts
@@ -17,6 +17,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/**/*.ts',
     '!<rootDir>/db/index.ts',
     '!**/*.d.ts',
+    '!<rootDir>/*.config.ts',
     '!**/__tests__/**',
     '!<rootDir>/core/**',
   ],


### PR DESCRIPTION
Jest supports `jest.config.ts` configuration file since [v26.6.0](https://github.com/facebook/jest/releases/tag/v26.6.0).
This PR migrates `jest.config.js` file to TypeScript, and make this repository **all** pure TypeScript!
## Ref
- https://jestjs.io/docs/configuration