### PR TITLE
fix(client): user's score is misjudged to be area's one

### DIFF
--- a/client/__tests__/components/shared/ScoreBoard.test.ts
+++ b/client/__tests__/components/shared/ScoreBoard.test.ts
@@ -41,7 +41,7 @@ describe('/components/shared/ScoreBoard.vue', () => {
       isArea: true,
     },
     {
-      userId: publicUser.id,
+      userId: '1user',
       userName: publicUser.name,
       clearLamp: 6,
       score: 999950,

--- a/client/__tests__/components/shared/__snapshots__/ScoreBoard.test.ts.snap
+++ b/client/__tests__/components/shared/__snapshots__/ScoreBoard.test.ts.snap
@@ -668,7 +668,7 @@ Array [
     "clearLamp": 6,
     "exScore": 409,
     "score": 999950,
-    "userId": "public_user",
+    "userId": "1user",
     "userName": "Public User",
   },
   Object {
@@ -703,7 +703,7 @@ Array [
     "clearLamp": 6,
     "exScore": 409,
     "score": 999950,
-    "userId": "public_user",
+    "userId": "1user",
     "userName": "Public User",
   },
   Object {

--- a/client/components/shared/ScoreBoard.vue
+++ b/client/components/shared/ScoreBoard.vue
@@ -209,13 +209,13 @@ export default class OrderDetailComponent extends Vue {
         fetchAllData ? 'full' : 'medium'
       )
       this.scores = scores.map(s => {
-        const id = parseInt(s.userId, 10)
-        if (!isNaN(id) && (areaCodeSet as ReadonlySet<number>).has(id)) {
+        const areaCodes = [...areaCodeSet].map(i => `${i}`)
+        if (areaCodes.includes(s.userId)) {
           return {
             ...s,
             isArea: true,
             userName: this.$t('list.top', {
-              area: this.$t(`area.${id}`),
+              area: this.$t(`area.${s.userId}`),
             }) as string,
           }
         }


### PR DESCRIPTION
User's score is misjudged to be area's one if `userId` starts with number, like "1user".
This PR fixes it.