### PR TITLE
feat(api): /scores/:uid (Get User Scores API)

### DIFF
--- a/api/scores__uid/README-ja.md
+++ b/api/scores__uid/README-ja.md
@@ -1,0 +1,74 @@
+# Get User Scores API
+
+English version is [here](./README.md).
+
+指定した条件と一致する、ユーザースコアの一覧を取得します。
+
+- [エンドポイント](#endpoint)
+- [パラメータ](#parameters)
+- [応答](#response)
+  - [本文](#response-body)
+- リンク
+  - [実装 (index.ts)](index.ts)
+  - [設定 (function.json)](function.json)
+  - [単体テスト (index.test.ts)](index.test.ts)
+
+## Endpoint
+
+認証は不要です。認証済ユーザーの場合は、非公開の場合でも自身のデータを取得できます。
+
+> GET api/v1/scores/*:userId*?style=1&diff=1&lv=5&lamp=5&rank=AAA
+
+## Parameters
+
+|名前|型|説明|
+|---|:--|---|
+|`userId`|string|ユーザーID|
+|`style`|integer?|`1`: SINGLE, `2`: DOUBLE|
+|`diff`|integer?|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
+|`lv`|integer?|譜面のレベル|
+|`clearLamp`|integer?|`0`: プレー済未クリア, `1`: アシストクリア, `2`: クリア, `3`: LIFE4, `4`: (Good) フルコンボ, `5`: グレートフルコンボ, `6`: PFC, `7`: MFC|
+|`rank`|string?|クリアランク (`E`～`AAA`)|
+
+## Response
+
+- パラメータと一致するスコアがない場合、`404 Not Found` を返します。
+- その他の場合、`200 OK` と [JSON](#response-body)を返します。
+
+### Response Body
+
+<details>
+  <summary>サンプル</summary>
+
+```json
+[
+  {
+    "songId": "QPd01OQqbOIiDoO1dbdo1IIbb60bqPdl",
+    "songName": "愛言葉",
+    "playStyle": 1,
+    "difficulty": 0,
+    "level": 3,
+    "score": 999950,
+    "clearLamp": 6,
+    "rank": "AAA",
+    "isCourse": false
+  }
+]
+```
+
+</details>
+
+|名前|型|説明|
+|---|:--:|--|
+|`songId`|string|曲ID (公式サイトより) `^([01689bdiloqDIOPQ]*){32}$`|
+|`songName`|string|曲名|
+|`playStyle`|integer|`1`: SINGLE, `2`: DOUBLE|
+|`difficulty`|integer|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
+|`level`|integer|譜面のレベル|
+|`score`|integer|通常スコア|
+|`exScore`|integer?|EXスコア (省略可)|
+|`maxCombo`|integer?|MAXコンボ数 (省略可)|
+|`clearLamp`|integer|`0`: プレー済未クリア, `1`: アシストクリア, `2`: クリア, `3`: LIFE4, `4`: (Good) フルコンボ, `5`: グレートフルコンボ, `6`: PFC, `7`: MFC|
+|`rank`|string|クリアランク (`E`～`AAA`)|
+|`deleted`|boolean?|Song is deleted or not|
+|`isCourse`|boolean|Course or not|

--- a/api/scores__uid/README-ja.md
+++ b/api/scores__uid/README-ja.md
@@ -27,7 +27,7 @@ English version is [here](./README.md).
 |`style`|integer?|`1`: SINGLE, `2`: DOUBLE|
 |`diff`|integer?|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
 |`lv`|integer?|譜面のレベル|
-|`clearLamp`|integer?|`0`: プレー済未クリア, `1`: アシストクリア, `2`: クリア, `3`: LIFE4, `4`: (Good) フルコンボ, `5`: グレートフルコンボ, `6`: PFC, `7`: MFC|
+|`lamp`|integer?|`0`: プレー済未クリア, `1`: アシストクリア, `2`: クリア, `3`: LIFE4, `4`: (Good) フルコンボ, `5`: グレートフルコンボ, `6`: PFC, `7`: MFC|
 |`rank`|string?|クリアランク (`E`～`AAA`)|
 
 ## Response

--- a/api/scores__uid/README.md
+++ b/api/scores__uid/README.md
@@ -1,0 +1,74 @@
+# Get User Scores API
+
+日本語版は[こちら](./README-ja.md)にあります。
+
+Get user scores that match the specified conditions.
+
+- [Endpoint](#endpoint)
+- [Parameters](#parameters)
+- [Response](#response)
+  - [Response Body](#response-body)
+- Links
+  - [Implements (index.ts)](index.ts)
+  - [Settings (function.json)](function.json)
+  - [Unit Test (index.test.ts)](index.test.ts)
+
+## Endpoint
+
+No need Authentication. Authenticated users can get their own data even if they are private.
+
+> GET api/v1/scores/*:userId*?style=1&diff=1&lv=5&lamp=5&rank=AAA
+
+## Parameters
+
+|Name|Type|Description|
+|----|:--:|-----------|
+|`userId`|string|User id|
+|`style`|integer?|`1`: SINGLE, `2`: DOUBLE|
+|`diff`|integer?|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
+|`lv`|integer?|Chart level|
+|`clearLamp`|integer?|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
+|`rank`|string?|Clear rank (`E`～`AAA`)|
+
+## Response
+
+- Returns `404 Not Found` if no score that matches parameters.
+- Returns `200 OK` with [JSON body](#response-body) otherwize.
+
+### Response Body
+
+<details>
+  <summary>Sample</summary>
+
+```json
+[
+  {
+    "songId": "QPd01OQqbOIiDoO1dbdo1IIbb60bqPdl",
+    "songName": "愛言葉",
+    "playStyle": 1,
+    "difficulty": 0,
+    "level": 3,
+    "score": 999950,
+    "clearLamp": 6,
+    "rank": "AAA",
+    "isCourse": false
+  }
+]
+```
+
+</details>
+
+|Name|Type|Description|
+|----|:--:|-----------|
+|`songId`|string|Song id that depend on official site. `^([01689bdiloqDIOPQ]*){32}$`|
+|`songName`|string|Song name|
+|`playStyle`|integer|`1`: SINGLE, `2`: DOUBLE|
+|`difficulty`|integer|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
+|`level`|integer|Chart level|
+|`score`|integer|Normal score|
+|`exScore`|integer?|EX SCORE (optional)|
+|`maxCombo`|integer?|MAX COMBO (optional)|
+|`clearLamp`|integer|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
+|`rank`|string|Clear rank (`E`～`AAA`)|
+|`deleted`|boolean?|Song is deleted or not|
+|`isCourse`|boolean|Course or not|

--- a/api/scores__uid/README.md
+++ b/api/scores__uid/README.md
@@ -27,7 +27,7 @@ No need Authentication. Authenticated users can get their own data even if they 
 |`style`|integer?|`1`: SINGLE, `2`: DOUBLE|
 |`diff`|integer?|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
 |`lv`|integer?|Chart level|
-|`clearLamp`|integer?|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
+|`lamp`|integer?|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
 |`rank`|string?|Clear rank (`E`～`AAA`)|
 
 ## Response

--- a/api/scores__uid/function.json
+++ b/api/scores__uid/function.json
@@ -1,0 +1,27 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "authLevel": "anonymous",
+      "methods": ["get"],
+      "route": "v1/scores/{uid:regex(^[-a-zA-Z0-9_]+$)}"
+    },
+    {
+      "name": "documents",
+      "type": "cosmosDB",
+      "direction": "in",
+      "databaseName": "DDRadar",
+      "collectionName": "Users",
+      "sqlQuery": "SELECT c.id, c.isPublic FROM c WHERE c.id = {uid}",
+      "connectionStringSetting": "COSMOS_DB_CONN"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ],
+  "scriptFile": "../dist/scores__uid/index.js"
+}

--- a/api/scores__uid/index.test.ts
+++ b/api/scores__uid/index.test.ts
@@ -1,0 +1,90 @@
+import type { HttpRequest } from '@azure/functions'
+import {
+  privateUser,
+  publicUser,
+  testScores,
+} from '@ddradar/core/__tests__/data'
+import { fetchScoreList } from '@ddradar/db'
+import { mocked } from 'ts-jest/utils'
+
+import { getLoginUserInfo } from '../auth'
+import getUserScores from '.'
+
+jest.mock('@ddradar/db')
+jest.mock('../auth')
+
+describe('GET /api/v1/scores', () => {
+  const req: Pick<HttpRequest, 'headers' | 'query'> = { headers: {}, query: {} }
+  beforeEach(() => mocked(getLoginUserInfo).mockResolvedValue(publicUser))
+
+  test('/not_found_user returns "404 Not Found"', async () => {
+    // Arrange - Act
+    const result = await getUserScores(null, req, [])
+
+    // Assert
+    expect(result.status).toBe(404)
+  })
+
+  test.each([null, publicUser])(
+    `/${privateUser.id} returns "404 Not Found" if login as %p`,
+    async user => {
+      // Arrange
+      mocked(getLoginUserInfo).mockResolvedValue(user)
+
+      // Act
+      const result = await getUserScores(null, req, [privateUser])
+
+      // Assert
+      expect(result.status).toBe(404)
+    }
+  )
+
+  test(`/${publicUser.id} returns "404 Not Found" if no score`, async () => {
+    // Arrange
+    mocked(fetchScoreList).mockResolvedValue([])
+
+    // Act
+    const result = await getUserScores(null, req, [publicUser])
+
+    // Assert
+    expect(result.status).toBe(404)
+  })
+
+  test.each([
+    [{}, {}],
+    [
+      { style: '1', diff: '1', lv: '5', lamp: '5', rank: 'AAA' },
+      { playStyle: 1, difficulty: 1, level: 5, clearLamp: 5, rank: 'AAA' },
+    ],
+    [{ style: '3', diff: '-1', lv: '21', lamp: 'PFC', rank: 'F' }, {}],
+  ])(
+    `/${publicUser.id} (query: %p) calls fetchScoreList("${publicUser.id}", %p)`,
+    async (query, expected) => {
+      // Arrange
+      mocked(fetchScoreList).mockResolvedValue([...testScores])
+      const req: Pick<HttpRequest, 'headers' | 'query'> = { headers: {}, query }
+
+      // Act
+      const result = await getUserScores(null, req, [publicUser])
+
+      // Assert
+      expect(result.status).toBe(200)
+      expect(result.body).toHaveLength(testScores.length)
+      expect(mocked(fetchScoreList)).toBeCalledWith(publicUser.id, expected)
+    }
+  )
+
+  test(`/${privateUser.id} returns "200 OK" with body if login as privateUser`, async () => {
+    // Arrange
+    mocked(getLoginUserInfo).mockResolvedValue(privateUser)
+    mocked(fetchScoreList).mockResolvedValue([...testScores])
+
+    // Act
+    const result = await getUserScores(null, req, [privateUser])
+
+    // Assert
+    expect(result.status).toBe(200)
+    expect(result.body).toHaveLength(testScores.length)
+    expect(mocked(fetchScoreList)).toBeCalledWith(privateUser.id, {})
+  })
+})

--- a/api/scores__uid/index.ts
+++ b/api/scores__uid/index.ts
@@ -1,0 +1,66 @@
+import type { HttpRequest } from '@azure/functions'
+import type { Api, Database } from '@ddradar/core'
+import { Score, Song } from '@ddradar/core'
+import { fetchScoreList } from '@ddradar/db'
+
+import { getClientPrincipal, getLoginUserInfo } from '../auth'
+import { ErrorResult, SuccessResult } from '../function'
+
+/** Get user scores that match the specified conditions. */
+export default async function (
+  _context: unknown,
+  req: Pick<HttpRequest, 'headers' | 'query'>,
+  [user]: Pick<Database.UserSchema, 'id' | 'isPublic'>[]
+): Promise<ErrorResult<404> | SuccessResult<Api.ScoreList[]>> {
+  const loginUser = await getLoginUserInfo(getClientPrincipal(req))
+  if (!user || (!user.isPublic && user.id !== loginUser?.id))
+    return new ErrorResult(404)
+
+  const { style, diff, lv, lamp, rank } = req.query
+
+  const playStyle = parseInt(style ?? '', 10)
+  const difficulty = parseInt(diff ?? '', 10)
+  const level = parseInt(lv ?? '', 10)
+  const clearLamp = parseInt(lamp ?? '', 10)
+
+  const conditions = {
+    ...(isPlayStyle(playStyle) ? { playStyle } : {}),
+    ...(isDifficulty(difficulty) ? { difficulty } : {}),
+    ...(isLevel(level) ? { level } : {}),
+    ...(isClearLamp(clearLamp) ? { clearLamp } : {}),
+    ...(isDanceLevel(rank) ? { rank } : {}),
+  }
+
+  const body = await fetchScoreList(user.id, conditions)
+  if (body.length === 0) return new ErrorResult(404)
+
+  return new SuccessResult(
+    body.map(d => {
+      const r = { ...d, isCourse: !!d.radar }
+      delete r.radar
+      return r
+    })
+  )
+
+  //#region Assertion Functions
+  function isPlayStyle(num: number): num is Song.PlayStyle {
+    return num === 1 || num === 2
+  }
+
+  function isDifficulty(num: number): num is Song.Difficulty {
+    return (Song.difficultyMap as Map<number, string>).has(num)
+  }
+
+  function isLevel(num: number): boolean {
+    return Number.isInteger(num) && num >= 1 && num <= 20
+  }
+
+  function isClearLamp(num: number): num is Score.ClearLamp {
+    return (Score.clearLampMap as Map<number, string>).has(num)
+  }
+
+  function isDanceLevel(str: string | undefined): str is Score.DanceLevel {
+    return (Score.danceLevelSet as Set<string>).has(rank ?? '')
+  }
+  //#endregion
+}

--- a/client/__tests__/api/score.test.ts
+++ b/client/__tests__/api/score.test.ts
@@ -3,6 +3,7 @@ import type { Api } from '@ddradar/core'
 import {
   deleteChartScore,
   getChartScore,
+  getUserScores,
   postChartScore,
   postSongScores,
 } from '~/api/score'
@@ -37,6 +38,42 @@ describe('./api/score.ts', () => {
         // Assert
         expect(result).toBe(scores)
         expect($http.$get).toBeCalledWith(uri)
+      }
+    )
+  })
+
+  describe('getUserScores', () => {
+    const _ = undefined
+    test.each([
+      [_, _, _, _, _, ''] as const,
+      [1, _, _, _, _, 'style=1'] as const,
+      [_, 3, _, _, _, 'diff=3'] as const,
+      [_, _, 12, _, _, 'lv=12'] as const,
+      [_, _, _, 5, _, 'lamp=5'] as const,
+      [_, _, _, _, 'AA+', 'rank=AA%2B'] as const,
+      [2, 4, 12, 4, 'AAA', 'style=2&diff=4&lv=12&lamp=4&rank=AAA'] as const,
+    ])(
+      '($http, "foo", %p, %p, %p, %p, "%s") calls GET "/api/v1/scores/foo?%s"',
+      async (playStyle, difficulty, level, clearLamp, rank, query) => {
+        // Arrange
+        const $http = { $get: jest.fn<Promise<any>, [string, any]>() }
+        $http.$get.mockResolvedValue([])
+
+        // Act
+        const result = await getUserScores(
+          $http,
+          'foo',
+          playStyle,
+          difficulty,
+          level,
+          clearLamp,
+          rank
+        )
+
+        // Assert
+        expect(result).toHaveLength(0)
+        expect($http.$get.mock.calls[0][0]).toBe('/api/v1/scores/foo')
+        expect($http.$get.mock.calls[0][1].searchParams.toString()).toBe(query)
       }
     )
   })

--- a/client/api/score.ts
+++ b/client/api/score.ts
@@ -1,4 +1,4 @@
-import type { Api } from '@ddradar/core'
+import type { Api, Score, Song } from '@ddradar/core'
 import type { NuxtHTTPInstance } from '@nuxt/http'
 
 import { apiPrefix } from '~/api'
@@ -10,8 +10,8 @@ import { apiPrefix } from '~/api'
 export function getChartScore(
   $http: Pick<NuxtHTTPInstance, '$get'>,
   songId: string,
-  playStyle: 1 | 2,
-  difficulty: 0 | 1 | 2 | 3 | 4,
+  playStyle: Song.PlayStyle,
+  difficulty: Song.Difficulty,
   scope?: 'private' | 'medium' | 'full'
 ) {
   const query = scope ? `?scope=${scope}` : ''
@@ -21,14 +21,42 @@ export function getChartScore(
 }
 
 /**
+ * Call "Get User Scores" API.
+ * @see https://github.com/ddradar/ddradar/tree/master/api/scores__uid/
+ */
+export function getUserScores(
+  $http: Pick<NuxtHTTPInstance, '$get'>,
+  userId: string,
+  playStyle?: Song.PlayStyle,
+  difficulty?: Song.Difficulty,
+  level?: number,
+  clearLamp?: Score.ClearLamp,
+  rank?: Score.DanceLevel
+) {
+  const searchParams = new URLSearchParams()
+  addParamIfDefined('style', playStyle)
+  addParamIfDefined('diff', difficulty)
+  addParamIfDefined('lv', level)
+  addParamIfDefined('lamp', clearLamp)
+  addParamIfDefined('rank', rank)
+  return $http.$get<Api.ScoreList[]>(`${apiPrefix}/scores/${userId}`, {
+    searchParams,
+  })
+
+  function addParamIfDefined(name: string, obj: number | string | undefined) {
+    if (obj !== undefined) searchParams.set(name, obj.toString())
+  }
+}
+
+/**
  * Call "Post Chart Score" API.
  * @see https://github.com/ddradar/ddradar/tree/master/api/scores__id__style__difficulty--post/
  */
 export function postChartScore(
   $http: Pick<NuxtHTTPInstance, '$post'>,
   songId: string,
-  playStyle: 1 | 2,
-  difficulty: 0 | 1 | 2 | 3 | 4,
+  playStyle: Song.PlayStyle,
+  difficulty: Song.Difficulty,
   score: Api.ScoreBody
 ) {
   return $http.$post(
@@ -44,8 +72,8 @@ export function postChartScore(
 export function deleteChartScore(
   $http: Pick<NuxtHTTPInstance, 'delete'>,
   songId: string,
-  playStyle: 1 | 2,
-  difficulty: 0 | 1 | 2 | 3 | 4
+  playStyle: Song.PlayStyle,
+  difficulty: Song.Difficulty
 ) {
   return $http.delete(`/api/v1/scores/${songId}/${playStyle}/${difficulty}`)
 }

--- a/core/api/score.ts
+++ b/core/api/score.ts
@@ -4,6 +4,17 @@ import { difficultyMap, playStyleMap } from '../song'
 import { hasIntegerProperty, hasProperty } from '../typeUtils'
 
 /**
+ * Object type returned by `/api/v1/scores/{:userId}`
+ * @see https://github.com/ddradar/ddradar/blob/master/api/scores__uid/
+ */
+export type ScoreList = Omit<
+  ScoreSchema,
+  'userId' | 'userName' | 'isPublic' | 'radar'
+> & {
+  isCourse: boolean
+}
+
+/**
  * Object type returned by `/api/v1/scores/{:songId}/{:playStyle}/{:difficulty}`
  * @see https://github.com/ddradar/ddradar/blob/master/api/scores__id__style__difficulty--get/
  */

--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ddradar/core",
   "description": "Core module for DDRadar",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.6",
   "author": "Nogic <24802730+nogic1008@users.noreply.github.com>",
   "repository": "https://github.com/ddradar/ddradar",
   "engines": {


### PR DESCRIPTION
## Endpoint

No need Authentication.
Authenticated users can get their own data even if they are private.

> GET api/v1/scores/*:userId*?style=1&diff=1&lv=5&lamp=5&rank=AAA

## Parameters

|Name|Type|Description|
|----|:--:|-----------|
|`userId`|string|User id|
|`style`|integer?|`1`: SINGLE, `2`: DOUBLE|
|`diff`|integer?|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
|`lv`|integer?|Chart level|
|`lamp`|integer?|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
|`rank`|string?|Clear rank (`E`～`AAA`)|

## Response

- Returns `404 Not Found` if no score that matches parameters.
- Returns `200 OK` with [JSON body](#response-body) otherwize.

### Response Body

<details>
  <summary>Sample</summary>

```json
[
  {
    "songId": "QPd01OQqbOIiDoO1dbdo1IIbb60bqPdl",
    "songName": "愛言葉",
    "playStyle": 1,
    "difficulty": 0,
    "level": 3,
    "score": 999950,
    "clearLamp": 6,
    "rank": "AAA",
    "isCourse": false
  }
]
```

</details>

|Name|Type|Description|
|----|:--:|-----------|
|`songId`|string|Song id that depend on official site. `^([01689bdiloqDIOPQ]*){32}$`|
|`songName`|string|Song name|
|`playStyle`|integer|`1`: SINGLE, `2`: DOUBLE|
|`difficulty`|integer|`0`: BEGINNER, `1`: BASIC, `2`: DIFFICULT, `3`: EXPERT, `4`: CHALLENGE|
|`level`|integer|Chart level|
|`score`|integer|Normal score|
|`exScore`|integer?|EX SCORE (optional)|
|`maxCombo`|integer?|MAX COMBO (optional)|
|`clearLamp`|integer|`0`: Failed, `1`: Assisted Clear `2`: Clear, `3`: LIFE4, `4`: Good FC (Full Combo), `5`: Great FC, `6`: PFC, `7`: MFC|
|`rank`|string|Clear rank (`E`～`AAA`)|
|`deleted`|boolean?|Song is deleted or not|
|`isCourse`|boolean|Course or not|
