### PR TITLE
fix(api): fix wrong isCourse

### DIFF
--- a/api/scores__uid/index.ts
+++ b/api/scores__uid/index.ts
@@ -72,7 +72,7 @@ export default async function (
 
   return new SuccessResult(
     body.map(d => {
-      const r = { ...d, isCourse: !!d.radar }
+      const r = { ...d, isCourse: !d.radar }
       delete r.radar
       return r
     })


### PR DESCRIPTION
`GET api/v1/scores/:uid?style=:style&diff=:diff&lv=5&lamp=:lamp&rank=:rank` returns wrong `isCourse`