### PR TITLE
fix(ci): use `ubuntu-18.04` host for DB integration test

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -36,7 +36,7 @@ jobs:
           - 10255:10255
         options: -m 3g --cpus=2.0
         env:
-          AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 3
+          AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 5
           AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: false
 
     steps:

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   test:
     name: Cosmos DB Integration Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     services:
       cosmos-db:
@@ -43,12 +43,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Get IP Address
-        run: echo ipaddr="`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1`" >> $GITHUB_ENV
-
       - name: Import emulator certificate
         run: |
-          while ! curl -k -f https://$ipaddr:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
+          while ! curl -k -f https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
           sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
           sudo update-ca-certificates
 
@@ -64,5 +61,5 @@ jobs:
       - name: Test (only *.db.test.ts)
         run: yarn test ".+\.db\.test\.ts" --passWithNoTests
         env:
-          COSMOS_DB_CONN: AccountEndpoint=https://$ipaddr:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+          COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Import emulator certificate
+      - name: Import DB Emulator Certificate
         run: |
           while ! curl -k -f https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
           sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
@@ -62,3 +62,4 @@ jobs:
         run: yarn test ".+\.db\.test\.ts" --passWithNoTests --colors
         env:
           COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+          NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -59,7 +59,6 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test (only *.db.test.ts)
-        run: yarn test ".+\.db\.test\.ts" --passWithNoTests
+        run: yarn test ".+\.db\.test\.ts" --passWithNoTests --colors
         env:
           COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
-          NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -40,6 +40,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+
+      - name: Import emulator certificate
+        run: |
+          while ! curl -k -f https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
+          sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
+
       - name: Use Node.js 12
         uses: actions/setup-node@v2.5.1
         with:
@@ -52,5 +59,5 @@ jobs:
       - name: Test (only *.db.test.ts)
         run: yarn test ".+\.db\.test\.ts" --passWithNoTests
         env:
-          COSMOS_DB_CONN: AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+          COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -28,11 +28,13 @@ jobs:
         image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
         ports:
           - 8081:8081
+          - 10250:10250
           - 10251:10251
           - 10252:10252
           - 10253:10253
           - 10254:10254
-        options: '-m 3g --cpus=2.0'
+          - 10255:10255
+        options: -m 3g --cpus=2.0
         env:
           AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 3
           AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: false

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -34,8 +34,8 @@ jobs:
           - 10254:10254
         options: '-m 3g --cpus=2.0'
         env:
-          AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 5
-          AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: true
+          AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 3
+          AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
+      - name: Get IP Address
+        run: echo ipaddr="`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}' | head -n 1`" >> $GITHUB_ENV
+
       - name: Import emulator certificate
         run: |
-          while ! curl -k -f https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
+          while ! curl -k -f https://$ipaddr:8081/_explorer/emulator.pem > ~/emulatorcert.crt; do sleep 5; done
           sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
           sudo update-ca-certificates
 
@@ -61,5 +64,5 @@ jobs:
       - name: Test (only *.db.test.ts)
         run: yarn test ".+\.db\.test\.ts" --passWithNoTests
         env:
-          COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+          COSMOS_DB_CONN: AccountEndpoint=https://$ipaddr:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -30,7 +30,6 @@ jobs:
           - 10252:10252
           - 10253:10253
           - 10254:10254
-          - 10255:10255
         options: '-m 3g --cpus=2.0'
         env:
           AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 5
@@ -51,5 +50,5 @@ jobs:
       - name: Test (only *.db.test.ts)
         run: yarn test ".+\.db\.test\.ts" --passWithNoTests
         env:
-          COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+          COSMOS_DB_CONN: AccountEndpoint=https://127.0.0.1:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'db/**'
       - '**.db.test.ts'
+      - '.github/workflows/db-integration.yml'
       - '!**.md'
   pull_request:
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - 'db/**'
       - '**.db.test.ts'
+      - '.github/workflows/db-integration.yml'
       - '!**.md'
 
 jobs:


### PR DESCRIPTION
fix #827
Workaround for Azure/azure-cosmos-db-emulator-docker#45