### PR TITLE
fix: convert old `songId` when post scores

### DIFF
--- a/api/scores__id--post/function.json
+++ b/api/scores__id--post/function.json
@@ -14,7 +14,7 @@
       "direction": "in",
       "databaseName": "DDRadar",
       "collectionName": "Songs",
-      "sqlQuery": "SELECT c.id, c.name, c.deleted, c.charts FROM c WHERE c.id = {id} OR c.skillAttackId = StringToNumber({id})",
+      "sqlQuery": "SELECT c.id, c.name, c.deleted, c.charts FROM c WHERE c.id = {id} OR c.skillAttackId = StringToNumber({id}) OR ({id} = 'dll9D90dq1O09oObO66Pl8l9I9l0PbPP' AND c.id = '01lbO69qQiP691ll6DIiqPbIdd9O806o')",
       "connectionStringSetting": "COSMOS_DB_CONN_READONLY"
     },
     {

--- a/functions/postSongScores/function.json
+++ b/functions/postSongScores/function.json
@@ -14,7 +14,7 @@
       "direction": "in",
       "databaseName": "DDRadar",
       "collectionName": "Songs",
-      "sqlQuery": "SELECT c.id, c.name, c.charts FROM c WHERE c.id = {songId}",
+      "sqlQuery": "SELECT c.id, c.name, c.charts FROM c WHERE c.id = {songId} OR ({songId} = 'dll9D90dq1O09oObO66Pl8l9I9l0PbPP' AND c.id = '01lbO69qQiP691ll6DIiqPbIdd9O806o')",
       "connectionStringSetting": "COSMOS_DB_CONN_READONLY"
     },
     {


### PR DESCRIPTION
- API
  - POST `v1/scores/{id}`
- Functions
  - POST `v1/scores/{songId}/{userId}`

From: dll9D90dq1O09oObO66Pl8l9I9l0PbPP
To: 01lbO69qQiP691ll6DIiqPbIdd9O806o