### PR TITLE
ci: prepare CI trigger for `develop/**` branch

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'develop/**'
     paths:
       - 'db/**'
       - '**.db.test.ts'

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -60,7 +60,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test (only *.db.test.ts)
-        run: yarn test ".+\.db\.test\.ts" --passWithNoTests --colors
+        run: yarn test ".+\.db\.test\.ts" --passWithNoTests --colors --testTimeout=20000
         env:
           COSMOS_DB_CONN: AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'develop/**'
     paths-ignore:
       - '**.md'
 


### PR DESCRIPTION
- Launch GitHub Actions on Pull Requested to `develop/**` branch
  - [Node.js CI](https://github.com/ddradar/ddradar/actions/workflows/nodejs.yml)
  - [Cosmos DB Integration](https://github.com/ddradar/ddradar/actions/workflows/db-integration.yml)
- Add [`--testTimeout`](https://jestjs.io/docs/cli#--testtimeoutnumber) option to prevent test error